### PR TITLE
Don't leak a TokenStream in Ctxt::emit_errors.

### DIFF
--- a/oauth1-request-derive/src/ctxt.rs
+++ b/oauth1-request-derive/src/ctxt.rs
@@ -6,22 +6,22 @@ use quote::ToTokens;
 use crate::util::error;
 
 pub struct Ctxt {
-    errors: TokenStream,
+    errors: Option<TokenStream>,
 }
 
 impl Ctxt {
     pub fn new() -> Self {
         Self {
-            errors: TokenStream::new(),
+            errors: Some(TokenStream::new()),
         }
     }
 
     pub fn error(&mut self, msg: &str, span: Span) {
-        error(msg, span).to_tokens(&mut self.errors);
+        error(msg, span).to_tokens(self.errors.as_mut().unwrap());
     }
 
     pub fn emit_errors(mut self) -> Option<TokenStream> {
-        let errors = mem::replace(&mut self.errors, TokenStream::new());
+        let errors = self.errors.take().unwrap();
         mem::forget(self);
         if errors.is_empty() {
             None


### PR DESCRIPTION
This was found by crater on https://github.com/rust-lang/rust/pull/63809 (results at https://github.com/rust-lang/rust/pull/64398#issuecomment-532887229).

While there is no *resource* leak being caused (as `proc_macro` "objects" get cleaned up anyway), we might want `rustc` to warn/error in such cases because they can also be caused by keeping a `proc_macro` "object" (such as a `TokenStream`) for longer than the scope of the proc macro invocation.