### PR TITLE
Handle nested `syn::Type:::Group`

### DIFF
--- a/oauth1-request-derive/src/method_body.rs
+++ b/oauth1-request-derive/src/method_body.rs
@@ -47,7 +47,11 @@ impl<'a> ToTokens for MethodBody<'a> {
                 }
 
                 let ty_is_option = f.meta.option.get().map(|v| **v).unwrap_or_else(|| {
-                    if let Type::Path(ref ty_path) = f.ty {
+                    let mut ty = &f.ty;
+                    while let Type::Group(g) = ty {
+                        ty = &g.elem;
+                    }
+                    if let Type::Path(ref ty_path) = ty {
                         let path = &ty_path.path;
                         path.leading_colon.is_none()
                             && path.segments.len() == 1


### PR DESCRIPTION
Currently, rustc does not pass the exact original TokenStream to
proc-macros in several cases. This has many undesirable effects, such as
losing correct location information in error message.
See rust-lang/rust#43081 for more details

In the future, rustc will begin passing the correct TokenStream to
proc-macros. As a result, `syn` may wrap a type in one or more
`syn::Type::Group`s (if the proc-macro input came from a `macro_rules!` expansion).

I've determined that this can cause `oauth1-request-derive` to fail to match
a `Type::Path`. This PR should properly handle nested groups, allowing
your crate to work with both old and new input.

If you have any questions, feel free to ask me. See rust-lang/rust#72622
for more details.