### PR TITLE
credentials: Use `AsRef<str>` instead of `Borrow<str>`

### DIFF
--- a/examples/src/client/auth.rs
+++ b/examples/src/client/auth.rs
@@ -1,6 +1,5 @@
 //! Functions to retrieve token credentials from the server.
 
-use std::borrow::Borrow;
 use std::fmt::Debug;
 
 use bytes::Bytes;
@@ -14,7 +13,7 @@ pub async fn temporary_credentials<T, S, B>(
     http: S,
 ) -> Credentials<Box<str>>
 where
-    T: Borrow<str>,
+    T: AsRef<str>,
     S: Service<http::Request<B>, Response = http::Response<B>>,
     S::Error: Debug,
     B: http_body::Body<Error = S::Error> + Default + From<Vec<u8>>,
@@ -35,8 +34,8 @@ pub async fn token_credentials<C, T, S, B>(
     http: S,
 ) -> Credentials<Box<str>>
 where
-    C: Borrow<str>,
-    T: Borrow<str>,
+    C: AsRef<str>,
+    T: AsRef<str>,
     S: Service<http::Request<B>, Response = http::Response<B>>,
     S::Error: Debug,
     B: http_body::Body<Error = S::Error> + Default + From<Vec<u8>>,

--- a/examples/src/client/request.rs
+++ b/examples/src/client/request.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 use http::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use oauth_credentials::Token;
 use tower_service::Service;
@@ -25,8 +23,8 @@ macro_rules! request {
                 http: S,
             ) -> S::Future
             where
-                C: std::borrow::Borrow<str>,
-                T: std::borrow::Borrow<str>,
+                C: AsRef<str>,
+                T: AsRef<str>,
                 S: tower_service::Service<http::Request<B>>,
                 B: Default + From<Vec<u8>>,
             {
@@ -49,8 +47,8 @@ pub trait SendRequest: oauth::Request {
 
     fn send<C, T, S, B>(&self, token: &Token<C, T>, http: S) -> S::Future
     where
-        C: Borrow<str>,
-        T: Borrow<str>,
+        C: AsRef<str>,
+        T: AsRef<str>,
         S: Service<http::Request<B>>,
         B: Default + From<Vec<u8>>,
     {

--- a/oauth-credentials/src/lib.rs
+++ b/oauth-credentials/src/lib.rs
@@ -19,7 +19,6 @@ extern crate core as std;
 #[cfg(feature = "serde")]
 mod serde_imp;
 
-use std::borrow::Borrow;
 use std::fmt::{self, Debug, Formatter};
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -105,7 +104,7 @@ pub struct Token<C, T = C> {
     pub token: Credentials<T>,
 }
 
-impl<T: Borrow<str>> Credentials<T> {
+impl<T: AsRef<str>> Credentials<T> {
     /// Creates a new `Credentials`.
     pub fn new(identifier: T, secret: T) -> Self {
         Credentials {
@@ -116,12 +115,12 @@ impl<T: Borrow<str>> Credentials<T> {
 
     /// Returns the unique identifier part of the credentials pair.
     pub fn identifier(&self) -> &str {
-        self.identifier.borrow()
+        self.identifier.as_ref()
     }
 
     /// Returns the shared secret part of the credentials pair.
     pub fn secret(&self) -> &str {
-        self.secret.borrow()
+        self.secret.as_ref()
     }
 
     /// Converts from `&Credentials<T>` to `Credentials<&str>`.
@@ -150,13 +149,13 @@ impl<T> Credentials<T> {
     pub fn map<U, F>(self, mut f: F) -> Credentials<U>
     where
         F: FnMut(T) -> U,
-        U: Borrow<str>,
+        U: AsRef<str>,
     {
         Credentials::new(f(self.identifier), f(self.secret))
     }
 }
 
-impl<'a, T: Borrow<str>> From<&'a Credentials<T>> for Credentials<&'a str> {
+impl<'a, T: AsRef<str>> From<&'a Credentials<T>> for Credentials<&'a str> {
     fn from(credentials: &'a Credentials<T>) -> Self {
         credentials.as_ref()
     }
@@ -185,7 +184,7 @@ impl<T: Debug> Debug for Credentials<T> {
     }
 }
 
-impl<C: Borrow<str>, T: Borrow<str>> Token<C, T> {
+impl<C: AsRef<str>, T: AsRef<str>> Token<C, T> {
     /// Creates a new `Token`.
     pub fn new(client: Credentials<C>, token: Credentials<T>) -> Self {
         Token {
@@ -224,9 +223,8 @@ impl<C, T> Token<C, T> {
     /// # Example
     ///
     /// ```edition2018
-    /// # use std::borrow::Borrow;
     /// # use oauth_credentials::{Credentials, Token};
-    /// async fn get_token<C: Borrow<str>, T: Borrow<str>>(temporary: Token<C, T>) -> Token<C, String> {
+    /// async fn get_token<C: AsRef<str>, T: AsRef<str>>(temporary: Token<C, T>) -> Token<C, String> {
     ///     // ...
     /// #     Token::new(temporary.client, Credentials::new("", "").map(Into::into))
     /// }
@@ -239,7 +237,7 @@ impl<C, T> Token<C, T> {
     pub fn map_client<C2, F>(self, f: F) -> Token<C2, T>
     where
         F: FnMut(C) -> C2,
-        C2: Borrow<str>,
+        C2: AsRef<str>,
     {
         Token {
             client: self.client.map(f),
@@ -253,9 +251,8 @@ impl<C, T> Token<C, T> {
     /// # Example
     ///
     /// ```edition2018
-    /// # use std::borrow::Borrow;
     /// # use oauth_credentials::{Credentials, Token};
-    /// async fn get_token<C: Borrow<str>, T: Borrow<str>>(temporary: Token<C, T>) -> Token<C, String> {
+    /// async fn get_token<C: AsRef<str>, T: AsRef<str>>(temporary: Token<C, T>) -> Token<C, String> {
     ///     // ...
     /// #     Token::new(temporary.client, Credentials::new("", "").map(Into::into))
     /// }
@@ -268,7 +265,7 @@ impl<C, T> Token<C, T> {
     pub fn map_token<T2, F>(self, f: F) -> Token<C, T2>
     where
         F: FnMut(T) -> T2,
-        T2: Borrow<str>,
+        T2: AsRef<str>,
     {
         Token {
             client: self.client,
@@ -283,7 +280,6 @@ impl<T> Token<T> {
     /// # Example
     ///
     /// ```edition2018
-    /// # use std::borrow::Borrow;
     /// # use oauth_credentials::Token;
     /// async fn get_token() -> Token {
     ///     // ...
@@ -297,7 +293,7 @@ impl<T> Token<T> {
     pub fn map<U, F>(self, mut f: F) -> Token<U>
     where
         F: FnMut(T) -> U,
-        U: Borrow<str>,
+        U: AsRef<str>,
     {
         self.map_client(&mut f).map_token(f)
     }
@@ -305,7 +301,7 @@ impl<T> Token<T> {
 
 impl<'a, 'b> Token<&'a str, &'b str> {
     /// Creates a new `Token<&str, &str>` from a pair of `&Credentials<_>`.
-    pub fn from_ref<C: Borrow<str>, T: Borrow<str>>(
+    pub fn from_ref<C: AsRef<str>, T: AsRef<str>>(
         client: &'a Credentials<C>,
         token: &'b Credentials<T>,
     ) -> Self {
@@ -313,7 +309,7 @@ impl<'a, 'b> Token<&'a str, &'b str> {
     }
 }
 
-impl<'a, C: Borrow<str>, T: Borrow<str>> From<&'a Token<C, T>> for Token<&'a str> {
+impl<'a, C: AsRef<str>, T: AsRef<str>> From<&'a Token<C, T>> for Token<&'a str> {
     fn from(token: &'a Token<C, T>) -> Self {
         token.as_ref()
     }

--- a/oauth1-request/src/lib.rs
+++ b/oauth1-request/src/lib.rs
@@ -173,7 +173,6 @@ pub use request::Request;
 pub use signature_method::HmacSha1;
 pub use signature_method::Plaintext;
 
-use std::borrow::Borrow;
 use std::fmt::{Debug, Display};
 use std::num::NonZeroU64;
 use std::str;
@@ -191,7 +190,7 @@ pub struct Builder<'a, SM, C = String, T = C> {
     options: auth::Options<'a>,
 }
 
-impl<'a, SM: SignatureMethod, C: Borrow<str>, T: Borrow<str>> Builder<'a, SM, C, T> {
+impl<'a, SM: SignatureMethod, C: AsRef<str>, T: AsRef<str>> Builder<'a, SM, C, T> {
     /// Creates a `Builder` that signs requests using the specified client credentials
     /// and signature method.
     pub fn new(client: Credentials<C>, signature_method: SM) -> Self {
@@ -406,8 +405,8 @@ macro_rules! def_shorthand {
         where
             U: Display,
             R: Request + ?Sized,
-            C: Borrow<str>,
-            T: Borrow<str>,
+            C: AsRef<str>,
+            T: AsRef<str>,
             SM: SignatureMethod,
         {
             authorize($method, uri, request, token, signature_method)
@@ -475,8 +474,8 @@ pub fn authorize<U, R, C, T, SM>(
 where
     U: Display,
     R: Request + ?Sized,
-    C: Borrow<str>,
-    T: Borrow<str>,
+    C: AsRef<str>,
+    T: AsRef<str>,
     SM: SignatureMethod,
 {
     fn inner<U, R, SM>(

--- a/oauth1-request/src/request.rs
+++ b/oauth1-request/src/request.rs
@@ -1,6 +1,5 @@
 //! Requests to be authorized with OAuth.
 
-use std::borrow::Borrow;
 use std::collections::BTreeSet;
 
 use crate::serializer::{Serializer, SerializerExt};
@@ -57,7 +56,7 @@ impl Request for () {
     }
 }
 
-impl<K: Borrow<str>, V: Borrow<str>> Request for BTreeSet<(K, V)> {
+impl<K: AsRef<str>, V: AsRef<str>> Request for BTreeSet<(K, V)> {
     fn serialize<S>(&self, mut serializer: S) -> S::Output
     where
         S: Serializer,
@@ -65,7 +64,7 @@ impl<K: Borrow<str>, V: Borrow<str>> Request for BTreeSet<(K, V)> {
         let mut next_param = OAuthParameter::default();
 
         for (k, v) in self {
-            let (k, v) = (k.borrow(), v.borrow());
+            let (k, v) = (k.as_ref(), v.as_ref());
             while next_param < *k {
                 next_param.serialize(&mut serializer);
                 next_param = next_param.next();


### PR DESCRIPTION
`Credentials` and `Token` do not take advantage of [`Borrow<T>`] trait's constraint that a type which implements `Borrow<T>` behaves identical to `T`:

[`Borrow<T>`]: <https://doc.rust-lang.org/std/borrow/trait.Borrow.html>

Due to this constraint, the number of implementors of `Borrow<T>` is fewer than that of `AsRef<T>`, limiting the ability of the users of `Credentials` and `Token`.

One of few examples where a type implements `Borrow<T>` but not `AsRef<T>` is the blanket implementation `impl<T> Borrow<T> for T`, but this is not the case for `Credentials` and `Token` because `str` is an unsized type and `Credentials` and `Token` cannot hold it directly.

This is a breaking change since `Borrow<T>` is not a subtrait of `AsRef<T>`, but the impact should not be too massive because any type which implements `Borrow<T>` _can_ implement `AsRef<T>` and such a type typically implements `AsRef<T>` in fact (this is at least the case for all `std` types).