### PR TITLE
Fix panic getting timestamp on `wasm32-unknown-unknown` target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         target:
           -
         features:
-          -
-          - derive
-          - hmac-sha1
+          - js
+          - js,derive
+          - js,hmac-sha1
         include:
           - toolchain: stable
-            features: ''
+            features: js
             target: wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,29 +16,50 @@ jobs:
           - beta
           - nightly
           - '1.46.0'
+        target:
+          -
         features:
           -
           - derive
           - hmac-sha1
+        include:
+          - toolchain: stable
+            features: ''
+            target: wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
           profile: minimal
           override: true
         id: toolchain
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.target }}
+      - name: Install `wasm-bindgen-test-runner`
+        if: matrix.target == 'wasm32-unknown-unknown'
+        run: |
+          VER=0.2.78
+          NAME="wasm-bindgen-$VER-x86_64-unknown-linux-musl"
+          DIGEST=14f1b0ef9225370f0d270efbdbbfe2cf5eb191d57b8eec14ade69c98c71e226f
+          curl -fLOsS "https://github.com/rustwasm/wasm-bindgen/releases/download/$VER/$NAME.tar.gz"
+          sha256sum --check --quiet <<< "$DIGEST $NAME.tar.gz"
+          tar -xzf "$NAME.tar.gz" "$NAME/wasm-bindgen-test-runner"
+          mv "$NAME/wasm-bindgen-test-runner" /usr/local/bin/
       - run: echo 'RUSTFLAGS=--allow unknown_lints' >> $GITHUB_ENV
         if: matrix.toolchain == '1.46.0'
+      - run: echo 'CARGO_BUILD_TARGET=${{ matrix.target }}' >> $GITHUB_ENV
+        if: matrix.target != ''
       - name: Build `oauth1-request`
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --verbose --tests --manifest-path oauth1-request/Cargo.toml --features=${{ matrix.features }}
       - name: Build `examples`
-        if: ${{ matrix.toolchain != '1.46.0' }}
+        if: ${{ matrix.target == '' && matrix.toolchain != '1.46.0' }}
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/oauth1-request/Cargo.toml
+++ b/oauth1-request/Cargo.toml
@@ -35,6 +35,9 @@ sha-1 = { version = "0.9", optional = true }
 oauth1-request = { version = "0.5", path = "", default-features = false }
 version-sync = "0.9"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+js-sys = "0.3"
+
 [features]
 default = ["derive", "hmac-sha1"]
 derive = ["oauth1-request-derive"]

--- a/oauth1-request/Cargo.toml
+++ b/oauth1-request/Cargo.toml
@@ -30,13 +30,14 @@ either = { version = "1.2", optional = true }
 hmac = { version = "0.11", optional = true }
 sha-1 = { version = "0.9", optional = true }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+# `js` feature
+js-sys = { version = "0.3", optional = true }
+
 [dev-dependencies]
 # Trick to make `proc-macro-crate` work in doctests.
 oauth1-request = { version = "0.5", path = "", default-features = false }
 version-sync = "0.9"
-
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-js-sys = "0.3"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -46,4 +47,5 @@ wasm-bindgen-test = "0.3"
 default = ["derive", "hmac-sha1"]
 derive = ["oauth1-request-derive"]
 hmac-sha1 = ["hmac", "sha-1"]
+js = ["js-sys"]
 serde = ["oauth-credentials/serde"]

--- a/oauth1-request/Cargo.toml
+++ b/oauth1-request/Cargo.toml
@@ -38,6 +38,10 @@ version-sync = "0.9"
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = "0.3"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen-test = "0.3"
+
 [features]
 default = ["derive", "hmac-sha1"]
 derive = ["oauth1-request-derive"]

--- a/oauth1-request/src/serializer/auth.rs
+++ b/oauth1-request/src/serializer/auth.rs
@@ -276,7 +276,7 @@ impl<'a, SM: SignatureMethod> Serializer for Authorizer<'a, SM> {
 fn get_current_timestamp() -> u64 {
     cfg_if::cfg_if! {
         // `std::time::SystemTime::now` is not supported and panics on `wasm32-unknown-unknown` target
-        if #[cfg(all(target_arch = "wasm32", target_os = "unknown"))] {
+        if #[cfg(all(feature = "js", target_arch = "wasm32", target_os = "unknown"))] {
             (js_sys::Date::now() / 1000.0) as u64
         } else {
             use std::time::{SystemTime, UNIX_EPOCH};

--- a/oauth1-request/src/serializer/auth.rs
+++ b/oauth1-request/src/serializer/auth.rs
@@ -3,7 +3,6 @@
 use std::fmt::{Display, Write};
 use std::num::NonZeroU64;
 use std::str;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use rand::prelude::*;
 
@@ -235,11 +234,7 @@ impl<'a, SM: SignatureMethod> Serializer for Authorizer<'a, SM> {
             let t = if let Some(t) = self.options.timestamp {
                 t.get()
             } else {
-                match SystemTime::now().duration_since(UNIX_EPOCH) {
-                    Ok(d) => d.as_secs(),
-                    #[cold]
-                    Err(_) => 1,
-                }
+                get_current_timestamp()
             };
             append_to_header!(self, encoded timestamp, t);
         }
@@ -275,6 +270,22 @@ impl<'a, SM: SignatureMethod> Serializer for Authorizer<'a, SM> {
         write!(authorization, r#""{}""#, sign.end()).unwrap();
 
         authorization
+    }
+}
+
+fn get_current_timestamp() -> u64 {
+    cfg_if::cfg_if! {
+        // `std::time::SystemTime::now` is not supported and panics on `wasm32-unknown-unknown` target
+        if #[cfg(all(target_arch = "wasm32", target_os = "unknown"))] {
+            (js_sys::Date::now() / 1000.0) as u64
+        } else {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            match SystemTime::now().duration_since(UNIX_EPOCH) {
+                Ok(d) => d.as_secs(),
+                #[cold]
+                Err(_) => 1,
+            }
+        }
     }
 }
 

--- a/oauth1-request/tests/pull_9.rs
+++ b/oauth1-request/tests/pull_9.rs
@@ -1,0 +1,14 @@
+//! Test for <https://github.com/tesaguri/oauth1-request-rs/pull/9>.
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[test]
+fn pull_9() {
+    let _ = oauth1_request::get(
+        "",
+        &(),
+        &oauth_credentials::Token::from_parts("", "", "", ""),
+        oauth1_request::HmacSha1,
+    );
+}


### PR DESCRIPTION
`std::time::SystemTime::now` on `wasm32-unknown-unknown` target is not supported and panics. [Related discussion](https://github.com/rust-lang/rust/issues/48564).

This PR fixes this issue by using `js_sys::Date::now` as a replacement, assuming there's JavaScript environment available at runtime.